### PR TITLE
correct seperator in ebnf's keyword-argument

### DIFF
--- a/fluent.ebnf
+++ b/fluent.ebnf
@@ -46,5 +46,5 @@ call-expression      ::= builtin '(' __ arglist? __ ')';
 arglist              ::= argument (__ ',' __ arglist)?;
 argument             ::= expression
                       |  keyword-argument;
-keyword-argument     ::= identifier __ '=' __ quoted-pattern;
+keyword-argument     ::= identifier __ ':' __ quoted-pattern;
 member-expression    ::= identifier '[' keyword ']';


### PR DESCRIPTION
There seems to be an incosistency in the example code you're giving anywhere, and the EBNF grammar specified. The EBNF grammar specifies the keyword argument to be as follows:

```
keyword-argument     ::= identifier __ '=' __ quoted-pattern;
```

While all examples (including example code in issues of this repository) define it as follows:

```
keyword-argument     ::= identifier __ ':' __ quoted-pattern;
```

This PR fixes that inconsistency, using `:` instead of `=`, such that others developing FTL software don't make a mistake based on an incorrect EBNF grammar.

For example currently [the incomplete L20n.cs library](https://github.com/polylingo/l20n.cs), parses FTL files using `=` as the keyword-argument's separator character, which is thus apparently incorrect.

In case the EBNF grammar was the correct one, we should probably start updating all example code, such that there is no confusion any longer.