### PR TITLE
Fix #8. Forbid patterns as values of call-expression's key-value arguments.

### DIFF
--- a/fluent.asdl
+++ b/fluent.asdl
@@ -14,13 +14,15 @@ module Fluent
          | CallExpression(iden callee, expr* args)
          | SelectExpression(expr exp, mem* vars)
          | MemberExpression(expr obj, memkey key)
-         | KeyValueArgument(iden name, expr* val)
+         | KeyValueArgument(iden name, argval val)
          | Number(string value)
          | String(string value)
 
     mem = Member(memkey key, pat value, bool default)
     memkey = Number(string value)
            | Keyword(iden? ns, key name)
+    argval = Number(string value)
+           | String(string value)
     
     iden = (string name)
     key = (string name)

--- a/fluent.ebnf
+++ b/fluent.ebnf
@@ -46,4 +46,4 @@ call-expression      ::= builtin '(' __ arglist? __ ')'
 arglist              ::= argument (__ ',' __ arglist)?
 argument             ::= expression
                        | keyword-argument
-keyword-argument     ::= identifier __ ':' __ quoted-pattern
+keyword-argument     ::= identifier __ ':' __ ('"' quoted-text? '"' | number)


### PR DESCRIPTION
This still suffers from the fact that `quoted-text` currently allows newlines. I'll fix that in 0.3.