### PR TITLE
Fix #3. Use { and } for explicit grouping

### DIFF
--- a/fluent.asdl
+++ b/fluent.asdl
@@ -9,14 +9,16 @@ module Fluent
 
     pat = Pattern(expr* elements, bool quoted)
 
-    expr = MessageReference(iden id)
-         | ExternalArgument(iden id)
-         | CallExpression(iden callee, expr* args)
-         | SelectExpression(expr exp, mem* vars)
-         | MemberExpression(expr obj, memkey key)
-         | KeyValueArgument(iden name, argval val)
-         | Number(string value)
-         | String(string value)
+    expr = Selector(sel)
+         | SelectExpression(sel sel, mem* vars)
+
+    sel = MessageReference(iden id)
+        | ExternalArgument(iden id)
+        | CallExpression(iden callee, expr* args)
+        | MemberExpression(expr obj, memkey key)
+        | KeyValueArgument(iden name, argval val)
+        | Number(string value)
+        | String(string value)
 
     mem = Member(memkey key, pat value, bool default)
     memkey = Number(string value)

--- a/fluent.ebnf
+++ b/fluent.ebnf
@@ -32,15 +32,17 @@ quoted-text          ::= ([^{"] | '\{' | '\"')+
 block-text           ::= NL __ '|' unquoted-pattern
 
 placeable            ::= '{' __ expression __ '}'
-expression           ::= quoted-pattern
+expression           ::= selector-expression | select-expression
+
+selector-expression  ::= quoted-pattern
                        | number
                        | identifier
                        | variable
-                       | select-expression
                        | member-expression
                        | call-expression
+                       | placeable
 
-select-expression    ::= expression __ ' ->' __ variants-list
+select-expression    ::= selector-expression __ ' ->' __ variants-list
 member-expression    ::= identifier '[' keyword ']'
 call-expression      ::= builtin '(' __ arglist? __ ')'
 arglist              ::= argument (__ ',' __ arglist)?


### PR DESCRIPTION
This only changes the EBNF grammar and doesn't change the ASDL. The grouping is supposed to help the parser in potentially ambiguous situations. Once the parser figures out the parse tree, the final AST will be unambiguous.