### PR TITLE
Fix #6. New syntax for attributes

### DIFF
--- a/fluent.asdl
+++ b/fluent.asdl
@@ -2,7 +2,7 @@ module Fluent
 {
     res = Resource(entry* body, comment? comment)
 
-    entry = Message(iden id, pat? value, mem* traits, comment? comment)
+    entry = Message(iden id, pat? value, attr* attrs, comment? comment)
           | Section(key key, entry* body, comment? comment)
           | Comment(comment)
           | Junk(string body)
@@ -10,19 +10,22 @@ module Fluent
     pat = Pattern(expr* elements, bool quoted)
 
     expr = Selector(sel)
-         | SelectExpression(sel? sel, mem* vars)
+         | SelectExpression(sel? sel, var* vars)
 
     sel = MessageReference(iden id)
         | ExternalArgument(iden id)
         | CallExpression(iden callee, expr* args)
-        | VariantExpression(expr obj, memkey key)
+        | VariantExpression(iden msg, varkey key)
+        | AttributeExpression(iden msg, iden id)
         | KeyValueArgument(iden name, argval val)
         | Number(string value)
         | String(string value)
 
-    mem = Member(memkey key, pat value, bool default)
-    memkey = Number(string value)
-           | Keyword(iden? ns, key name)
+    attr = Attribute(iden id, pat value)
+    var = Variant(varkey key, pat value, bool default)
+    varkey = Number(string value)
+           | Keyword(key name)
+
     argval = Number(string value)
            | String(string value)
     

--- a/fluent.ebnf
+++ b/fluent.ebnf
@@ -10,19 +10,21 @@ char                 ::= [https://www.w3.org/TR/REC-xml/#NT-Char]
 __                   ::= [#x20#x9]*   /* space, tab */
 NL                   ::= [#xA#xD]+    /* line feed, carriage return */
 
-identifier           ::= [a-zA-Z_.?-] ([a-zA-Z0-9_.?-])*
+identifier           ::= [a-zA-Z_?-] ([a-zA-Z0-9_?-])*
 variable             ::= '$' identifier
 keyword              ::= [a-zA-Z_.?-] ([a-zA-Z0-9_.?- ]* [a-zA-Z0-9_.?-])?
 builtin              ::= [A-Z_.?-]+
 number               ::= [0-9]+ ('.' [0-9]+)?
 
-member-key           ::= number | (identifier '/')? keyword
-member               ::= '[' member-key ']' __ pattern NL
-default-member       ::= '*' member
-variants-list        ::= NL (__ member)* __ default-member (__ member)*
-traits-list          ::= variants-list | NL (__ member)+
+variant-key          ::= number | keyword
+variant              ::= '[' variant-key ']' __ pattern NL
+default-variant      ::= '*' variant
+variant-list         ::= NL (__ variant)* __ default-variant (__ variant)*
 
-message              ::= identifier __ '=' __ (pattern | pattern traits-list | traits-list)
+attribute            ::= '.' identifier __ '=' __ pattern NL
+attribute-list       ::= NL (__ attribute)+
+
+message              ::= identifier __ '=' __ (pattern attribute-list? | attribute-list)
 pattern              ::= unquoted-pattern
                        | quoted-pattern
 unquoted-pattern     ::= (unquoted-text | placeable | block-text)+
@@ -38,11 +40,13 @@ selector-expression  ::= quoted-pattern
                        | number
                        | identifier
                        | variable
-                       | member-expression
+                       | attribute-expression
+                       | variant-expression
                        | call-expression
                        | placeable
 
-select-expression    ::= selector-expression __ ' ->' __ variants-list
+select-expression    ::= selector-expression __ ' ->' __ variant-list
+attribute-expression ::= identifier '.' identifier
 variant-expression   ::= identifier '[' keyword ']'
 call-expression      ::= builtin '(' __ arglist? __ ')'
 arglist              ::= argument (__ ',' __ arglist)?

--- a/guide.rst
+++ b/guide.rst
@@ -259,41 +259,19 @@ without a selector and referred to from other messages, like the ``about``
 message above.
 
 
-Storing Additional Information
-==============================
-
-::
-
-    brand-name = Firefox
-        [gender] masculine
-
-    opened-new-window = { brand-name[gender] ->
-       *[masculine] { brand-name } otworzyl nowe okno.
-        [feminine] { brand-name } otworzyla nowe okno.
-    }
-
-Traits can be used to describe parameters of the entity that can be then
-used in other selectors.
-
-Imagine an entity ``brand-name`` that can be either *Firefox* or *Aurora*.  The 
-former is *masculine*, while the latter is *feminine*, so sentences that refer 
-to this entity may want to branch depending on the gender of it.
-
-
-HTML/XUL Attributes
-===================
+DOM Attributes
+==============
 
 ::
 
     login-input = Predefined value
-        [html/placeholder] example@email.com
-        [html/aria-label]  Login input value
-        [html/title]       Type your login email
+        .placeholder = example@email.com
+        .aria-label = Login input value
+        .title = Type your login email
 
-Traits can also be very useful when using FTL for localization of more 
-complex UI elements, such as HTML components.
+Use attributes when localizing more complex UI components such as DOM elements.
 
-Those elements often contain multiple translatable messages per one widget. For 
+UI elements often contain multiple translatable messages per one widget. For 
 example, an HTML form input may have a value, but also a ``placeholder`` 
 attribute, ``aria-label`` attribute and maybe a ``title`` attribute.
 


### PR DESCRIPTION
This implements the following proposal from #6 for the syntax for public attributes:

```
file-open
  .label     = File Open
  .accesskey = O 
```

I also removed namespaces from variant keys. Attributes are public. The API returns the value and all attributes for a given identifier.

I removed the section on storing private grammatical information from the guide. I'll bring it back in #7.
