### PR TITLE
Simplify Expressions

### DIFF
--- a/fluent.asdl
+++ b/fluent.asdl
@@ -8,24 +8,19 @@ module Fluent
           | Junk(string body)
 
     -- Pattern values
-    pat = Pattern(elem* elements, bool quoted)
-    elem = String(string)
-         | Placeable(plcbl)
+    pat = Pattern(expr* elements, bool quoted)
 
-    -- Expressions allowed inside of braced Placeables
-    plcbl = Expression(expr)
-          | SelectExpression(expr? expr, var* vars)
-
-    -- Expressions allowed as selectors of SelectExpression and
-    -- arguments to CallExpression
+    -- Expressions
     expr = Pattern(pat)
+         | String(string)
          | Number(number)
          | MessageReference(iden id)
          | ExternalArgument(iden id)
+         | SelectExpression(expr? expr, var* vars)
          | AttributeExpression(iden id, iden name)
          | VariantExpression(iden id, varkey key)
          | CallExpression(fun callee, arg* args)
-         | Placeable(plcbl)
+         | Expression(expr)
 
     -- Attributes of Message
     attr = Attribute(iden id, pat value)


### PR DESCRIPTION
This simplifies the ASDL by merging `elem`, the explicit `plcbl` type and
`expr` into a single `expr` type.

The previous version was inspired directly by the EBNF grammar and reflected
the grouping of expressions achieved by using additional braces pairs right in
the AST.  The purpose of the grouping is to help the parser disamiguate the
syntax.  The produced AST however, by its tree-like structure, is never
ambiguous with regard to operator precedence.

A more explicit AST can help serialization: upon seeing a Placeable data type
the serializer knows to serialize it wrapped in braces.  However, the
serializer will still need to check the parents of Patterns to decide if they
should be wrapped in quotes or not.  The same technique can be used when
serializing Expressions without sacrifices to the type-strictness of the AST.

The resulting AST is simpler than the previous one.